### PR TITLE
API can provide products sorted in categories

### DIFF
--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,4 +1,4 @@
 class Product < ApplicationRecord
-  validates_presence_of :name, :price
+  validates_presence_of :name, :price, :category
   enum category: [:starter, :entree, :dessert]
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,3 +1,4 @@
 class Product < ApplicationRecord
   validates_presence_of :name, :price
+  enum category: [:starter, :entree, :dessert]
 end

--- a/db/migrate/20200305160943_add_category_to_products.rb
+++ b/db/migrate/20200305160943_add_category_to_products.rb
@@ -1,0 +1,5 @@
+class AddCategoryToProducts < ActiveRecord::Migration[6.0]
+  def change
+    add_column :products, :category, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,18 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_03_143554) do
+ActiveRecord::Schema.define(version: 2020_03_05_160943) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "products", force: :cascade do |t|
-    t.bigint "category_id"
     t.string "name"
     t.string "description"
     t.float "price"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "category"
   end
 
   create_table "users", force: :cascade do |t|

--- a/spec/factories/products.rb
+++ b/spec/factories/products.rb
@@ -3,5 +3,6 @@ FactoryBot.define do
     name { "Swedish meatballs" }
     description { "Swedish meatballs with mashed potatoes and lingonberry jam" }
     price { 21.0 }
+    category { "entree" }
   end
 end

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -5,10 +5,12 @@ RSpec.describe Product, type: :model do
     it  {is_expected.to have_db_column :name}
     it  {is_expected.to have_db_column :description}
     it  {is_expected.to have_db_column :price}
+    it  {is_expected.to have_db_column :category}
   end
   describe 'Validations' do
     it {is_expected.to validate_presence_of :name}
     it {is_expected.to validate_presence_of :price}
+    it {is_expected.to validate_presence_of :category}
   end
 
   describe 'Factory' do


### PR DESCRIPTION
# [PT Story](https://www.pivotaltracker.com/story/show/171466964)

```
As a restaurant API
In order to give the client better sorted products
I would like to be able to send off the products with their category listed 
```

## Changes proposed in this pull request:
* Add category attribute to the product model (enum)
* Make sure that the index endpoint returns the product category
## What I have learned working on this feature:
* Modifying User model with rails migrations
* Implementing enum parameters to update tables with new columns

