### PR TITLE
User can sign up

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   mount_devise_token_auth_for 'User', at: 'api/auth', skip: [:omniauth_callbacks]
-  namespace :api do
+  namespace :api, defaults: { format: :json } do
     resources :products, only: [:index]
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -3,5 +3,6 @@ FactoryBot.define do
     email { "user@mail.com" }
     password { "password" }
     password_confirmation { "password" }
+    name {"Mike Shum"}
   end
 end

--- a/spec/requests/api/user_spec.rb
+++ b/spec/requests/api/user_spec.rb
@@ -11,14 +11,17 @@ RSpec.describe 'POST /api/auth/', type: :request do
           },
           headers: headers
     end
+
     it 'returns a 200 response status' do
       expect(response).to have_http_status 200
     end
+
     it 'returns a success message' do
       binding.pry
       expect(JSON.parse(response.body)['status']).to eq 'success'
     end
   end
+
   context 'when a user submits' do
     describe 'a non-matching password confirmation' do
       before do
@@ -31,13 +34,16 @@ RSpec.describe 'POST /api/auth/', type: :request do
             },
             headers: headers
       end
+
       it 'returns a 422 response status' do
         expect(response).to have_http_status 422
       end
+
       it 'returns an error message' do
         expect(JSON.parse(response.body)['errors']['password_confirmation']).to eq ["doesn't match Password"]
       end
     end
+
     describe 'an invalid email address' do
       before do
         post '/api/auth/',
@@ -49,13 +55,16 @@ RSpec.describe 'POST /api/auth/', type: :request do
             },
             headers: headers
       end
+
       it 'returns a 422 response status' do
         expect(response).to have_http_status 422
       end
+
       it 'returns an error message' do
         expect(JSON.parse(response.body)['errors']['email']).to eq ['is not an email']
       end
     end
+
     describe 'an already registered email' do
       let!(:registered_user) { create(:user, email: 'firstuser@mail.com') }
       before do
@@ -67,9 +76,11 @@ RSpec.describe 'POST /api/auth/', type: :request do
             },
             headers: headers
       end
+
       it 'returns a 422 response status' do
         expect(response).to have_http_status 422
       end
+      
       it 'returns an error message' do
         expect(JSON.parse(response.body)['errors']['email']).to eq ['has already been taken']
       end

--- a/spec/requests/api/user_spec.rb
+++ b/spec/requests/api/user_spec.rb
@@ -17,7 +17,6 @@ RSpec.describe 'POST /api/auth/', type: :request do
     end
 
     it 'returns a success message' do
-      binding.pry
       expect(JSON.parse(response.body)['status']).to eq 'success'
     end
   end

--- a/spec/requests/api/user_spec.rb
+++ b/spec/requests/api/user_spec.rb
@@ -1,0 +1,78 @@
+RSpec.describe 'POST /api/auth/', type: :request do
+  let(:headers) { { HTTP_ACCEPT: 'application/json' } }
+  describe 'with valid credentials' do
+    before do
+      post '/api/auth/',
+          params: {
+            email: 'user@mail.com',
+            password: 'password',
+            password_confirmation: 'password',
+            name: 'Mike Shum'
+          },
+          headers: headers
+    end
+    it 'returns a 200 response status' do
+      expect(response).to have_http_status 200
+    end
+    it 'returns a success message' do
+      binding.pry
+      expect(JSON.parse(response.body)['status']).to eq 'success'
+    end
+  end
+  context 'when a user submits' do
+    describe 'a non-matching password confirmation' do
+      before do
+        post '/api/auth/',
+            params: {
+              email: 'user@mail.com',
+              password: 'password',
+              password_confirmation: 'wrong_password',
+              name: 'Mike Shum'
+            },
+            headers: headers
+      end
+      it 'returns a 422 response status' do
+        expect(response).to have_http_status 422
+      end
+      it 'returns an error message' do
+        expect(JSON.parse(response.body)['errors']['password_confirmation']).to eq ["doesn't match Password"]
+      end
+    end
+    describe 'an invalid email address' do
+      before do
+        post '/api/auth/',
+            params: {
+              email: 'user@mail',
+              password: 'password',
+              password_confirmation: 'password',
+              name: 'Mike Shum'
+            },
+            headers: headers
+      end
+      it 'returns a 422 response status' do
+        expect(response).to have_http_status 422
+      end
+      it 'returns an error message' do
+        expect(JSON.parse(response.body)['errors']['email']).to eq ['is not an email']
+      end
+    end
+    describe 'an already registered email' do
+      let!(:registered_user) { create(:user, email: 'firstuser@mail.com') }
+      before do
+        post '/api/auth/',
+            params: {
+              email: 'firstuser@mail.com',
+              password: 'password',
+              password_confirmation: 'password'
+            },
+            headers: headers
+      end
+      it 'returns a 422 response status' do
+        expect(response).to have_http_status 422
+      end
+      it 'returns an error message' do
+        expect(JSON.parse(response.body)['errors']['email']).to eq ['has already been taken']
+      end
+    end
+  end
+end


### PR DESCRIPTION
# [PT Story](https://www.pivotaltracker.com/story/show/171467075)
```
As a restaurant API
In order for users to order food
I would like to be able provide functionality to sign up
```
## Changes proposed in this pull request:
* Adding test for user registration
* Adding name to factory
## What I have learned working on this feature:
* Don't need separate routes and models for registration when using Devise