### PR TITLE
API provides functionality to create an order

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem 'pg', '>= 0.18', '< 2.0'
 gem 'puma', '~> 3.7'
 gem 'rack-cors', require: 'rack/cors'
 gem 'devise_token_auth'
+gem 'active_model_serializers'
 
 group :development, :test do
   gem 'coveralls', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,6 +37,11 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
+    active_model_serializers (0.10.10)
+      actionpack (>= 4.1, < 6.1)
+      activemodel (>= 4.1, < 6.1)
+      case_transform (>= 0.2)
+      jsonapi-renderer (>= 0.1.1.beta1, < 0.3)
     activejob (6.0.2.1)
       activesupport (= 6.0.2.1)
       globalid (>= 0.3.6)
@@ -61,6 +66,8 @@ GEM
       msgpack (~> 1.0)
     builder (3.2.4)
     byebug (11.1.1)
+    case_transform (0.2)
+      activesupport
     coderay (1.1.2)
     concurrent-ruby (1.1.6)
     coveralls (0.8.23)
@@ -94,6 +101,7 @@ GEM
     i18n (1.8.2)
       concurrent-ruby (~> 1.0)
     json (2.3.0)
+    jsonapi-renderer (0.2.2)
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -217,6 +225,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active_model_serializers
   bootsnap (>= 1.2)
   coveralls
   devise_token_auth

--- a/app/controllers/api/orders_controller.rb
+++ b/app/controllers/api/orders_controller.rb
@@ -2,6 +2,20 @@ class Api::OrdersController < ApplicationController
   def create
     order = Order.create
     order.order_items.create(product_id: params[:product_id])
-    render json: { message: 'This item has been added to your order.', order_id: order.id }
+    render json: create_json_response(order)
+  end
+
+  def update
+    order = Order.find(params[:id])
+    product = Product.find(params[:product_id])
+    order.order_items.create(product: product)
+    render json: create_json_response(order)
+  end
+
+  private
+  
+  def create_json_response(order)
+    json = { order: OrderSerializer.new(order) }
+    json.merge!(message: 'The product has been added to your order')
   end
 end

--- a/app/controllers/api/orders_controller.rb
+++ b/app/controllers/api/orders_controller.rb
@@ -16,6 +16,6 @@ class Api::OrdersController < ApplicationController
   
   def create_json_response(order)
     json = { order: OrderSerializer.new(order) }
-    json.merge!(message: 'The product has been added to your order')
+    json.merge!(message: 'This item has been added to your order.')
   end
 end

--- a/app/controllers/api/orders_controller.rb
+++ b/app/controllers/api/orders_controller.rb
@@ -1,0 +1,7 @@
+class Api::OrdersController < ApplicationController
+  def create
+    order = Order.create
+    order.order_items.create(product_id: params[:product_id])
+    render json: { message: 'This item has been added to your order.', order_id: order.id }
+  end
+end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,0 +1,3 @@
+class Order < ApplicationRecord
+  has_many :order_items
+end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,3 +1,8 @@
 class Order < ApplicationRecord
   has_many :order_items
+
+  def order_total
+
+  order_items.joins(:product).sum('products.price')
+  end
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -2,7 +2,6 @@ class Order < ApplicationRecord
   has_many :order_items
 
   def order_total
-
-  order_items.joins(:product).sum('products.price')
+    order_items.joins(:product).sum('products.price')
   end
 end

--- a/app/models/order_item.rb
+++ b/app/models/order_item.rb
@@ -1,0 +1,4 @@
+class OrderItem < ApplicationRecord
+  belongs_to :order
+  belongs_to :product
+end

--- a/app/serializers/order_serializer.rb
+++ b/app/serializers/order_serializer.rb
@@ -1,0 +1,35 @@
+class OrderSerializer < ActiveModel::Serializer
+  attributes :id, :products_1, :products_2, :products_3, :products, :total, :order_total
+  def products_1
+    products = []
+    object.order_items.group_by(&:product_id).each do |key, value|
+      product = Product.find(key)
+      hash = { amount: value.count, name: product.name, total: (product.price * value.count) }
+      products.push hash
+    end
+    products
+  end
+  def products_2
+    products = []
+    unique_items = object.order_items.uniq(&:product)
+    unique_items_count = object.order_items.group_by(&:product_id).map { |key, value| [key, value.size] }.to_h
+    unique_items.each do |item|
+      products.push(
+        amount: unique_items_count[item.product_id],
+        name: item.product.name,
+        total: (unique_items_count[item.product_id] * item.product.price)
+      )
+    end
+    products
+  end
+  def products_3
+    object.order_items.group_by(&:product_id).map do |_key, value|
+      product = value.uniq(&:product_id)[0].product
+      { amount: value.size, name: product.name, total: (value.size * product.price) }
+    end
+	end
+	alias_method :products, :products_3
+  def total
+    object.order_items.joins(:product).sum('products.price')
+  end
+end

--- a/app/serializers/order_serializer.rb
+++ b/app/serializers/order_serializer.rb
@@ -1,34 +1,13 @@
 class OrderSerializer < ActiveModel::Serializer
-  attributes :id, :products_1, :products_2, :products_3, :products, :total, :order_total
-  def products_1
-    products = []
-    object.order_items.group_by(&:product_id).each do |key, value|
-      product = Product.find(key)
-      hash = { amount: value.count, name: product.name, total: (product.price * value.count) }
-      products.push hash
-    end
-    products
-  end
-  def products_2
-    products = []
-    unique_items = object.order_items.uniq(&:product)
-    unique_items_count = object.order_items.group_by(&:product_id).map { |key, value| [key, value.size] }.to_h
-    unique_items.each do |item|
-      products.push(
-        amount: unique_items_count[item.product_id],
-        name: item.product.name,
-        total: (unique_items_count[item.product_id] * item.product.price)
-      )
-    end
-    products
-  end
-  def products_3
+  attributes :id, :products, :total, :order_total
+
+  def products
     object.order_items.group_by(&:product_id).map do |_key, value|
       product = value.uniq(&:product_id)[0].product
       { amount: value.size, name: product.name, total: (value.size * product.price) }
     end
 	end
-	alias_method :products, :products_3
+
   def total
     object.order_items.joins(:product).sum('products.price')
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,7 @@
 Rails.application.routes.draw do
-  namespace :api do
-    get 'orders/create'
-  end
   mount_devise_token_auth_for 'User', at: 'api/auth', skip: [:omniauth_callbacks]
   namespace :api do
+    get 'orders/create'
     resources :products, only: [:index]
     resources :orders, only: [:create, :update]
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,10 @@
 Rails.application.routes.draw do
+  namespace :api do
+    get 'orders/create'
+  end
   mount_devise_token_auth_for 'User', at: 'api/auth', skip: [:omniauth_callbacks]
   namespace :api do
     resources :products, only: [:index]
+    resources :orders, only: [:create, :update]
   end
 end

--- a/db/migrate/20200307145626_create_orders.rb
+++ b/db/migrate/20200307145626_create_orders.rb
@@ -1,0 +1,8 @@
+class CreateOrders < ActiveRecord::Migration[6.0]
+  def change
+    create_table :orders do |t|
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200307145712_create_order_items.rb
+++ b/db/migrate/20200307145712_create_order_items.rb
@@ -1,0 +1,10 @@
+class CreateOrderItems < ActiveRecord::Migration[6.0]
+  def change
+    create_table :order_items do |t|
+      t.references :order, null: false, foreign_key: true
+      t.references :product, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,24 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_05_160943) do
+ActiveRecord::Schema.define(version: 2020_03_07_145712) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "order_items", force: :cascade do |t|
+    t.bigint "order_id", null: false
+    t.bigint "product_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["order_id"], name: "index_order_items_on_order_id"
+    t.index ["product_id"], name: "index_order_items_on_product_id"
+  end
+
+  create_table "orders", force: :cascade do |t|
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
 
   create_table "products", force: :cascade do |t|
     t.string "name"
@@ -52,4 +66,6 @@ ActiveRecord::Schema.define(version: 2020_03_05_160943) do
     t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true
   end
 
+  add_foreign_key "order_items", "orders"
+  add_foreign_key "order_items", "products"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,5 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
-#   Character.create(name: 'Luke', movie: movies.first)
+Product.create name: 'Swedish Meatballs', description: 'Really yummy and traditional...', price: 80, category: 'entree'
+Product.create name: 'Green Salad', description: 'Cripsy green salad with some vinegrette', price: 45, category: 'starter'
+Product.create name: 'Tiramisu', description: 'Just a traditional Tiramisu', price: 60, category: 'dessert'
+
+User.create name: 'Mike Shum', email: 'user@mail.com', password: 'password'

--- a/spec/factories/order_items.rb
+++ b/spec/factories/order_items.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :order_item do
+    order { nil }
+    product { nil }
+  end
+end

--- a/spec/factories/orders.rb
+++ b/spec/factories/orders.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :order do
+    
+  end
+end

--- a/spec/models/order_item_spec.rb
+++ b/spec/models/order_item_spec.rb
@@ -1,0 +1,6 @@
+require 'rails_helper'
+
+RSpec.describe OrderItem, type: :model do
+  it { is_expected.to belong_to :order }
+  it { is_expected.to belong_to :product }
+end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Order, type: :model do
+  it {is_expected.to have_many :order_items}
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -4,12 +4,14 @@ RSpec.describe User, type: :model do
   it "should have valid Factory" do
     expect(create(:user)).to be_valid
   end
+
   describe "Database table" do
     it { is_expected.to have_db_column :encrypted_password }
     it { is_expected.to have_db_column :email }
     it { is_expected.to have_db_column :name }
     it { is_expected.to have_db_column :tokens }
   end
+
   describe "Validations" do
     it { is_expected.to validate_presence_of :email }
     it { is_expected.to validate_confirmation_of :password }
@@ -20,6 +22,7 @@ RSpec.describe User, type: :model do
         it { is_expected.not_to allow_value(email).for(:email) }
       end
     end
+    
     context "should have a valid email address" do
       emails = ["asdf@ds.com", "hello@example.uk", "test1234@yahoo.si",
                 "asdf@example.eu"]

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -19,4 +19,5 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   config.include FactoryBot::Syntax::Methods
   config.include(Shoulda::Matchers::ActiveRecord, type: :model)
+  config.include ResponseJSON
 end

--- a/spec/requests/api/client_can_create_new_order_spec.rb
+++ b/spec/requests/api/client_can_create_new_order_spec.rb
@@ -1,11 +1,42 @@
+# frozen_string_literal: true
 RSpec.describe Api::OrdersController, type: :request do
-  let!(:product_1) { create(:product, name: 'Salad') }
-  let!(:product_2) { create(:product, name: 'Ice Cream') }
-    before do
-        post '/api/orders', params: { product_id: product_1.id }
-        @order_id = JSON.parse(response.body)['order_id']
+  let!(:product_1) { create(:product, name: 'Salad', price: 10) }
+  let!(:product_2) { create(:product, name: 'Ice Cream', price: 20) }
+  before do
+    post '/api/orders', params: { product_id: product_1.id }
+    order_id = JSON.parse(response.body)['order']['id']
+    @order = Order.find(order_id)
+  end
+  describe 'POST /api/orders' do
+    it 'responds with success message' do
+      expect(JSON.parse(response.body)['message']).to eq 'This item has been added to your order.'
     end
-  it 'responds with success message' do
-    expect(JSON.parse(response.body)['message']).to eq "This item has been added to your order."
+    it 'responds with order id' do
+      expect(JSON.parse(response.body)['order']['id']).to eq @order.id
+    end
+    it 'responds with right amount of products' do
+      expect(JSON.parse(response.body)['order']['products'].count).to eq 1
+		end
+		it 'responds with right order total' do
+      expect(JSON.parse(response.body)['order']['total']).to eq 10
+    end
+  end
+  describe 'PUT /api/orders/:id' do
+    before do
+      put "/api/orders/#{@order.id}", params: { product_id: product_2.id }
+      put "/api/orders/#{@order.id}", params: { product_id: product_2.id }
+    end
+    it 'adds another product to order if request is a PUT and param id of the order is present' do
+      expect(@order.order_items.count).to eq 3
+    end
+    it 'responds with order id' do
+      expect(JSON.parse(response.body)['order']['id']).to eq @order.id
+    end
+    it 'responds with right amount of unique products' do
+      expect(JSON.parse(response.body)['order']['products'].count).to eq 2
+    end
+    it 'responds with right order total' do
+      expect(JSON.parse(response.body)['order']['total']).to eq 50
+    end
   end
 end

--- a/spec/requests/api/client_can_create_new_order_spec.rb
+++ b/spec/requests/api/client_can_create_new_order_spec.rb
@@ -1,0 +1,11 @@
+RSpec.describe Api::OrdersController, type: :request do
+  let!(:product_1) { create(:product, name: 'Salad') }
+  let!(:product_2) { create(:product, name: 'Ice Cream') }
+    before do
+        post '/api/orders', params: { product_id: product_1.id }
+        @order_id = JSON.parse(response.body)['order_id']
+    end
+  it 'responds with success message' do
+    expect(JSON.parse(response.body)['message']).to eq "This item has been added to your order."
+  end
+end

--- a/spec/requests/api/new_order_spec.rb
+++ b/spec/requests/api/new_order_spec.rb
@@ -5,22 +5,22 @@ RSpec.describe Api::OrdersController, type: :request do
   
   before do
     post '/api/orders', params: { product_id: product_1.id }
-    order_id = JSON.parse(response.body)['order']['id']
+    order_id = (response_json)['order']['id']
     @order = Order.find(order_id)
   end
   
   describe 'POST /api/orders' do
     it 'responds with success message' do
-      expect(JSON.parse(response.body)['message']).to eq 'This item has been added to your order.'
+      expect((response_json)['message']).to eq 'This item has been added to your order.'
     end
     it 'responds with order id' do
-      expect(JSON.parse(response.body)['order']['id']).to eq @order.id
+      expect((response_json)['order']['id']).to eq @order.id
     end
     it 'responds with right amount of products' do
-      expect(JSON.parse(response.body)['order']['products'].count).to eq 1
+      expect((response_json)['order']['products'].count).to eq 1
 		end
 		it 'responds with right order total' do
-      expect(JSON.parse(response.body)['order']['total']).to eq 10
+      expect((response_json)['order']['total']).to eq 10
     end
   end
 
@@ -33,13 +33,13 @@ RSpec.describe Api::OrdersController, type: :request do
       expect(@order.order_items.count).to eq 3
     end
     it 'responds with order id' do
-      expect(JSON.parse(response.body)['order']['id']).to eq @order.id
+      expect((response_json)['order']['id']).to eq @order.id
     end
     it 'responds with right amount of unique products' do
-      expect(JSON.parse(response.body)['order']['products'].count).to eq 2
+      expect((response_json)['order']['products'].count).to eq 2
     end
     it 'responds with right order total' do
-      expect(JSON.parse(response.body)['order']['total']).to eq 50
+      expect((response_json)['order']['total']).to eq 50
     end
   end
 end

--- a/spec/requests/api/new_order_spec.rb
+++ b/spec/requests/api/new_order_spec.rb
@@ -2,11 +2,13 @@
 RSpec.describe Api::OrdersController, type: :request do
   let!(:product_1) { create(:product, name: 'Salad', price: 10) }
   let!(:product_2) { create(:product, name: 'Ice Cream', price: 20) }
+  
   before do
     post '/api/orders', params: { product_id: product_1.id }
     order_id = JSON.parse(response.body)['order']['id']
     @order = Order.find(order_id)
   end
+  
   describe 'POST /api/orders' do
     it 'responds with success message' do
       expect(JSON.parse(response.body)['message']).to eq 'This item has been added to your order.'
@@ -21,6 +23,7 @@ RSpec.describe Api::OrdersController, type: :request do
       expect(JSON.parse(response.body)['order']['total']).to eq 10
     end
   end
+
   describe 'PUT /api/orders/:id' do
     before do
       put "/api/orders/#{@order.id}", params: { product_id: product_2.id }

--- a/spec/support/response_json.rb
+++ b/spec/support/response_json.rb
@@ -1,0 +1,5 @@
+module ResponseJSON
+  def response_json
+    JSON.parse(response.body)
+  end
+end


### PR DESCRIPTION
# [PT Story](https://www.pivotaltracker.com/story/show/171467249)
```
As a restaurant API
In order for users to buy food they want from the restaurant
I would like to be able to create an order for a specific user
```
## Changes proposed in this pull request:
* Adds units specs for Orders controller, order model and orderitem model.
* Installed and added order serializer 
* Created controller and updated it with functionality
* Created model for Order and OrderItem
## What I have learned working on this feature:
* How to add association between models and db tables
* How to use a serializer
* How to break down a bigger task on the API side
* How to use the binding.pry in a useful and informative way 
* Got a bigger picture between how to manipulate the backend to match your frontend expectations, for example getting 2 x Dish instead of the dish showing up twice in the order
## Packages/Gems added
* active_model_serializers